### PR TITLE
Rename IEloService::CalculateElo to reflect full responsibility

### DIFF
--- a/Backend/API/Controllers/MatchesController.cs
+++ b/Backend/API/Controllers/MatchesController.cs
@@ -77,7 +77,7 @@ public class MatchesController(
 
             if (updateMatchDto.UpdateWinner)
             {
-                await eloService.CalculateElo(match);
+                await eloService.AdjustEloForMatch(match);
 
                 // Update rankings
                 var matches = await matchRepository.GetAll();

--- a/Backend/API/Services/EloService.cs
+++ b/Backend/API/Services/EloService.cs
@@ -1,4 +1,3 @@
-using Domain.Interfaces;
 using Domain.Interfaces.Repositories;
 using Domain.Interfaces.Services;
 using Domain.Models;
@@ -12,11 +11,11 @@ namespace API.Services;
 public class EloService(IUserRepository userRepository) : IEloService
 {
     /// <summary>
-    /// Calculates the Elo rating for a match.
+    /// Calculates and persists the Elo rating for each player based on a match.
     /// </summary>
     /// <param name="match">The match for which to calculate the Elo rating.</param>
     /// <exception cref="ArgumentException">Thrown when a player is not found.</exception>
-    public async Task CalculateElo(Match match)
+    public async Task AdjustEloForMatch(Match match)
     {
         var playerA = await userRepository.Get(match.Player1.Id);
         var playerB = await userRepository.Get(match.Player2.Id);

--- a/Backend/Domain/Interfaces/Services/IEloService.cs
+++ b/Backend/Domain/Interfaces/Services/IEloService.cs
@@ -4,5 +4,5 @@ namespace Domain.Interfaces.Services;
 
 public interface IEloService
 {
-    public Task CalculateElo(Match match);
+    public Task AdjustEloForMatch(Match match);
 }


### PR DESCRIPTION
`IEloService::CalculateElo` currently does more than just calculating an Elo. This PR renames the method to reflect that.